### PR TITLE
Fix iterating arrayref $headers when it is empty

### DIFF
--- a/lib/Email/Simple/Header.pm
+++ b/lib/Email/Simple/Header.pm
@@ -136,7 +136,7 @@ sub header_names {
 
   my %seen;
   grep  { !$seen{ lc $_ }++ }
-    map { $headers->[ $_ * 2 ] } 0 .. int($#$headers / 2);
+    map { $headers->[ $_ * 2 ] } 0 .. @$headers / 2 - 1;
 }
 
 =method header_raw_pairs
@@ -198,9 +198,9 @@ sub header_raw {
 
   if (wantarray) {
     return map { _str_value($headers->[ $_ * 2 + 1 ]) }
-      grep { lc $headers->[ $_ * 2 ] eq $lc_field } 0 .. int($#$headers / 2);
+      grep { lc $headers->[ $_ * 2 ] eq $lc_field } 0 .. @$headers / 2 - 1;
   } else {
-    for (0 .. int($#$headers / 2)) {
+    for (0 .. @$headers / 2 - 1) {
       return _str_value($headers->[ $_ * 2 + 1 ]) if lc $headers->[ $_ * 2 ] eq $lc_field;
     }
     return;
@@ -251,7 +251,7 @@ sub header_raw_set {
 
   my $lc_field = lc $field;
   my @indices = grep { lc $headers->[$_] eq $lc_field }
-    map { $_ * 2 } 0 .. int($#$headers / 2);
+    map { $_ * 2 } 0 .. @$headers / 2 - 1;
 
   if (@indices > @data) {
     my $overage = @indices - @data;

--- a/t/header-names.t
+++ b/t/header-names.t
@@ -1,4 +1,4 @@
-use Test::More tests => 9;
+use Test::More tests => 17;
 use strict;
 $^W = 1;
 
@@ -31,3 +31,24 @@ for my $email (@emails) {
     );
   }
 }
+
+my $warned;
+$SIG{__WARN__} = sub { $warned = 1; warn $_[0]; };
+
+my $email = Email::Simple->new('');
+
+$warned = 0;
+is_deeply([ $email->headers() ], [], 'method headers() returns empty list when no header was defined');
+ok(!$warned, 'method headers() does not produce any warning when no header was defined');
+
+$warned = 0;
+is_deeply([ $email->header_names() ], [], 'method header_names() returns empty list when no header was defined');
+ok(!$warned, 'method header_names() does not produce any warning when no header was defined');
+
+$warned = 0;
+is_deeply([ $email->header_raw('unknown') ], [], 'method header_raw returns empty list for unknwon header');
+ok(!$warned, 'method header_raw() does not produce any warning when no header was defined');
+
+$warned = 0;
+is_deeply([ $email->header_raw_set('new_header', 'new_value') ], [ 'new_value' ], 'method header_raw_set returns new set value');
+ok(!$warned, 'method header_raw_set() does not produce any warning when no header was defined');


### PR DESCRIPTION
Expression (0 .. int($#$headers / 2)) expand to list (0) when $headers is [].

It caused that both methods headers() and header_names() in list context
returned (undef) when there was no header defined. And it throw warning:
Use of uninitialized value $_ in lc at Email/Simple/Header.pm line 138.

Expression (0 .. @$headers / 2 - 1) expand to list () when $headers is [].

So it should fix it. Warnings were thrown also for header_raw() and
header_raw_set() methods.
