### PR TITLE
Add warnings when characters above 0xFF enter into Email::Simple

### DIFF
--- a/lib/Email/Simple.pm
+++ b/lib/Email/Simple.pm
@@ -78,6 +78,8 @@ sub new {
 
   my $text_ref = (ref $text || '' eq 'SCALAR') ? $text : \$text;
 
+  Carp::carp 'Message with wide characters' if ${$text_ref} =~ /[^\x00-\xFF]/;
+
   my ($pos, $mycrlf) = $class->_split_head_from_body($text_ref);
 
   my $self = bless { mycrlf => $mycrlf } => $class;
@@ -295,6 +297,7 @@ Sets the body text of the mail.
 sub body_set {
   my ($self, $text) = @_;
   my $text_ref = ref $text ? $text : \$text;
+  Carp::carp 'Body with wide characters' if defined ${$text_ref} and ${$text_ref} =~ /[^\x00-\xFF]/;
   $self->{body} = $text_ref;
   return;
 }

--- a/lib/Email/Simple/Creator.pm
+++ b/lib/Email/Simple/Creator.pm
@@ -3,6 +3,8 @@ use warnings;
 package Email::Simple::Creator;
 # ABSTRACT: private helper for building Email::Simple objects
 
+use Carp ();
+
 sub _crlf {
   "\x0d\x0a";
 }
@@ -17,6 +19,9 @@ our @CARP_NOT = qw(Email::Simple Email::MIME);
 sub _add_to_header {
   my ($class, $header, $key, $value) = @_;
   $value = '' unless defined $value;
+
+  Carp::carp "Header name '$key' with wide characters" if $key =~ /[^\x00-\xFF]/;
+  Carp::carp "Value '$value' for '$key' header with wide characters" if $value =~ /[^\x00-\xFF]/;
 
   if ($value =~ s/[\x0a\x0b\x0c\x0d\x85\x{2028}\x{2029}]+/ /g) {
     Carp::carp("replaced vertical whitespace in $key header with space; this will become fatal in a future version");

--- a/lib/Email/Simple/Header.pm
+++ b/lib/Email/Simple/Header.pm
@@ -5,6 +5,8 @@ package Email::Simple::Header;
 
 use Carp ();
 
+our @CARP_NOT = qw(Email::Simple);
+
 require Email::Simple;
 
 =head1 SYNOPSIS
@@ -58,6 +60,8 @@ sub new {
 
 sub _header_to_list {
   my ($self, $head, $mycrlf) = @_;
+
+  Carp::carp 'Header with wide characters' if ${$head} =~ /[^\x00-\xFF]/;
 
   my @headers;
 
@@ -244,6 +248,9 @@ you.)
 
 sub header_raw_set {
   my ($self, $field, @data) = @_;
+
+  Carp::carp "Header name '$field' with wide characters" if $field =~ /[^\x00-\xFF]/;
+  Carp::carp "Value for '$field' header with wide characters" if grep /[^\x00-\xFF]/, @data;
 
   # I hate this block. -- rjbs, 2006-10-06
   if ($Email::Simple::GROUCHY) {

--- a/t/above-0xFF.t
+++ b/t/above-0xFF.t
@@ -1,0 +1,25 @@
+use Test::More tests => 7;
+use Email::Simple;
+
+sub get_warning(&) {
+  my $message;
+  local $SIG{__WARN__} = sub { $message = $_[0] unless $message };
+  $_[0]->();
+  return $message;
+}
+
+like get_warning { Email::Simple->new("\N{U+100}: \N{U+100}") }, qr/^Message with wide characters at $0 /, 'Email::Simple->new warns with characters above 0xFF';
+
+like get_warning { Email::Simple->create(body => "\N{U+100}") }, qr/^Body with wide characters at $0 /, 'Email::Simple->create warns with characters above 0xFF in body';
+
+like get_warning { Email::Simple->create(header => [ "\N{U+100}" => "a" ]) }, qr/^Header name '\N{U+100}' with wide characters at $0 /, 'Email::Simple->create warns with characters above 0xFF in header name';
+
+like get_warning { Email::Simple->create(header => [ a => "\N{U+100}" ]) }, qr/^Value '\N{U+100}' for 'a' header with wide characters at $0 /, 'Email::Simple->create warns with characters above 0xFF in header value';
+
+my $m = Email::Simple->create();
+
+like get_warning { $m->body_set("\N{U+100}") }, qr/^Body with wide characters at $0 /, 'Email::Simple->header_set warns with characters above 0xFF in body';
+
+like get_warning { $m->header_set("\N{U+100}", "a") }, qr/^Header name '\N{U+100}' with wide characters at $0 /, 'Email::Simple->header_set warns with characters above 0xFF in header name';
+
+like get_warning { $m->header_set("a", "\N{U+100}") }, qr/^Value for 'a' header with wide characters at $0 /, 'Email::Simple->header_set warns with characters above 0xFF in header value';


### PR DESCRIPTION
Whole Email::Simple works with bytes, not with Unicode strings. Therefore
add safe warnings about unexpected characters which cannot be represented
as bytes and which would cause serious problems.

For now only throw warnings, in future it can be fatal error.