### PR TITLE
Avoid folding issue when header_raw_prepend is folded already

### DIFF
--- a/lib/Email/Simple.pm
+++ b/lib/Email/Simple.pm
@@ -39,9 +39,9 @@ sub __crlf_re { qr/\x0a\x0d|\x0d\x0a|\x0a|\x0d/; }
       ],
       body => '...',
   );
-  
+
   $email->header_set( 'X-Content-Container' => 'bottle/glass' );
-  
+
   print $email->as_string;
 
 =head1 DESCRIPTION

--- a/lib/Email/Simple/Header.pm
+++ b/lib/Email/Simple/Header.pm
@@ -315,18 +315,18 @@ This method returns the newline string used in the header.
 sub crlf { $_[0]->{mycrlf} }
 
 # =method fold
-# 
+#
 #   my $folded = $header->fold($line, \%arg);
-# 
+#
 # Given a header string, this method returns a folded version, if the string is
 # long enough to warrant folding.  This method is used internally.
-# 
+#
 # Valid arguments are:
-# 
+#
 #   at      - fold lines to be no longer than this length, if possible
 #             if given and false, never fold headers
 #   indent  - indent lines with this string
-# 
+
 # =cut
 
 sub _fold {
@@ -372,19 +372,19 @@ sub __fold_objless {
 }
 
 # =method default_fold_at
-# 
+#
 # This method (provided for subclassing) returns the default length at which to
 # try to fold header lines.  The default default is 78.
-# 
+#
 # =cut
 
 sub _default_fold_at { 78 }
 
 # =method default_fold_indent
-# 
+#
 # This method (provided for subclassing) returns the default string used to
 # indent folded headers.  The default default is a single space.
-# 
+#
 # =cut
 
 sub _default_fold_indent { " " }

--- a/lib/Email/Simple/Header.pm
+++ b/lib/Email/Simple/Header.pm
@@ -335,6 +335,9 @@ sub _fold {
 
   $arg->{at} = $self->_default_fold_at unless exists $arg->{at};
 
+  return $line if $line =~ /\r?\n$/;
+  return $line . $self->crlf if $line =~ /\r?\n/;;
+
   return $line . $self->crlf unless $arg->{at} and $arg->{at} > 0;
 
   my $limit  = ($arg->{at} || $self->_default_fold_at) - 1;
@@ -346,6 +349,7 @@ sub _fold {
   my $indent = $arg->{indent} || $self->_default_fold_indent;
 
   return $self->__fold_objless($line, $limit, $indent, $self->crlf);
+
 }
 
 sub __fold_objless {

--- a/t/folding.t
+++ b/t/folding.t
@@ -1,6 +1,6 @@
 #!perl -w
 use strict;
-use Test::More tests => 13;
+use Test::More tests => 14;
 
 # This time, with folding!
 

--- a/t/folding.t
+++ b/t/folding.t
@@ -1,6 +1,6 @@
 #!perl -w
 use strict;
-use Test::More tests => 11;
+use Test::More tests => 13;
 
 # This time, with folding!
 
@@ -80,5 +80,17 @@ END
   unlike($email_1->as_string(), qr/at the end\n\s+\n/, 'no double fold on line ending in newline' );
 
 
+  {
+    my @warnings;
+    my $string = do {
+      local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+      $email_1->header_raw_prepend( 'Test6', "Invalid\nFolding" );
+      $email_1->as_string;
+    };
+
+    is(@warnings, 1, "setting an invalidly-folded header emits a warning");
+    like($warnings[0], qr/bad space/, "...and it's the right one");
+    like($string, qr/Test6: Invalid\r?\n Folding\r?\n/, "header fixed");
+  }
 }
 


### PR DESCRIPTION
header_raw_prepend() allows any raw header to be added, including those which are already folded.

When calling as_string(), we call down to _fold(), and then down to __fold_objless() to do the actual folding if the header line is over the line limit.

… however …

__fold_objless() assumes that the line does not contain any newlines, evidenced by the comment in the method.

If we have a long line with a space and newline in just the right place then __fold_objless() will insert a spaces only line into the fold.

Proposed solution:

Do not try and fold if we detect newlines in the string to be folded.
